### PR TITLE
chore: Update workflow to use .NET 10 and clean up setup steps

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,7 +14,7 @@ env:
   DOTNET_SKIP_FIRST_TIME_EXPERIENCE: 1
   DOTNET_NOLOGO: true
   NuGetDirectory: ${{ github.workspace }}/nuget
-  DotNetVersion: '9.0.x'
+  DotNetVersion: '10.0.x'
 
 defaults:
   run:
@@ -28,7 +28,7 @@ jobs:
       with:
         fetch-depth: 0
 
-    - name: Setup .NET 9
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DotNetVersion }}
@@ -49,7 +49,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - name: Setup .NET 9
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DotNetVersion }}
@@ -68,7 +68,7 @@ jobs:
         name: nuget
         path: ${{ env.NuGetDirectory }}
 
-    - name: Setup .NET 9
+    - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:
         dotnet-version: ${{ env.DotNetVersion }}


### PR DESCRIPTION
Updated the GitHub Actions workflow to use .NET 10.0.x instead of 9.0.x by changing the DotNetVersion environment variable. Renamed "Setup .NET 9" steps to "Setup .NET" for clarity and ensured all jobs reference the updated version variable.